### PR TITLE
feat(azure_pipelines_scaler): add an option to enable demands to be c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Allow excluding labels from being propagated from ScaledObject and ScaledJob to generated HPA and Job objects ([#6849](https://github.com/kedacore/keda/issues/6849))
 - **General**: chore: only add webhook DNS names when webhook patching is enabled ([#7002](https://github.com/kedacore/keda/issues/7002))
 - **General**: Improve Events emitted from ScaledObject controller ([#6802](https://github.com/kedacore/keda/issues/6802))
+- **Azure Pipelines Scaler**: Add new `caseInsensitiveDemandsProcessing` property to enable case-insensitive comparison of pipeline job demands ([#7111](https://github.com/kedacore/keda/issues/7111))
 - **Azure Pipelines Scaler**: Add new `fetchUnfinishedJobsOnly` property to fetch only unfinished pipeline jobs for a pool ([#6819](https://github.com/kedacore/keda/issues/6819))
 - **Datadog Scaler**: Add a specific timeout configuration parameter for the Datadog trigger ([#6999](https://github.com/kedacore/keda/pull/6999))
 - **Datadog Scaler**: Fix bug with datadogNamespace config ([#6828](https://github.com/kedacore/keda/pull/6828))

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -148,6 +148,7 @@ type azurePipelinesMetadata struct {
 	triggerIndex                         int
 	RequireAllDemands                    bool `keda:"name=requireAllDemands,          order=triggerMetadata, default=false, optional"`
 	RequireAllDemandsAndIgnoreOthers     bool `keda:"name=requireAllDemandsAndIgnoreOthers,          order=triggerMetadata, default=false, optional"`
+	CaseInsensitiveDemandsProcessing     bool `keda:"name=caseInsensitiveDemandsProcessing,          order=triggerMetadata, default=false, optional"`
 }
 
 type authContext struct {
@@ -464,7 +465,13 @@ func getCanAgentDemandFulfilJob(jr JobRequest, metadata *azurePipelinesMetadata)
 
 	for _, demandInJob := range demandsInJob {
 		for _, demandInScaler := range demandsInScaler {
-			if demandInJob == demandInScaler {
+			var isMatch bool
+			if metadata.CaseInsensitiveDemandsProcessing {
+				isMatch = strings.EqualFold(demandInJob, demandInScaler)
+			} else {
+				isMatch = demandInJob == demandInScaler
+			}
+			if isMatch {
 				countDemands++
 			}
 		}

--- a/pkg/scalers/azure_pipelines_scaler_test.go
+++ b/pkg/scalers/azure_pipelines_scaler_test.go
@@ -412,6 +412,63 @@ func TestAzurePipelinesNotMatchedPartialRequiredTriggerDemands(t *testing.T) {
 	}
 }
 
+func TestAzurePipelinesDemandsComparisonDefaultCaseSensitive(t *testing.T) {
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// nosemgrep: no-direct-write-to-responsewriter
+		_, _ = w.Write(buildLoadJSON())
+	}))
+
+	meta := getDemandJobMetaData(apiStub.URL)
+	meta.RequireAllDemands = true
+	meta.Demands = "KUBECTL"
+
+	mockAzurePipelinesScaler := azurePipelinesScaler{
+		metadata:   meta,
+		httpClient: http.DefaultClient,
+	}
+
+	// nosemgrep: context-todo
+	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
+
+	if err != nil {
+		t.Fail()
+	}
+
+	if queuelen > 0 {
+		t.Fail()
+	}
+}
+
+func TestAzurePipelinesDemandsComparisonCaseInsensitive(t *testing.T) {
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// nosemgrep: no-direct-write-to-responsewriter
+		_, _ = w.Write(buildLoadJSON())
+	}))
+
+	meta := getDemandJobMetaData(apiStub.URL)
+	meta.RequireAllDemands = true
+	meta.Demands = "KUBECTL"
+	meta.CaseInsensitiveDemandsProcessing = true
+
+	mockAzurePipelinesScaler := azurePipelinesScaler{
+		metadata:   meta,
+		httpClient: http.DefaultClient,
+	}
+
+	// nosemgrep: context-todo
+	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
+
+	if err != nil {
+		t.Fail()
+	}
+
+	if queuelen < 1 {
+		t.Fail()
+	}
+}
+
 func buildLoadJSON() []byte {
 	output := testJobRequestResponse[0 : len(testJobRequestResponse)-2]
 	for i := 1; i < loadCount; i++ {
@@ -445,6 +502,7 @@ func TestAzurePipelinesQueueURLTest(t *testing.T) {
 		t.Run(testData.testName, func(t *testing.T) {
 			var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
+				// nosemgrep: no-direct-write-to-responsewriter
 				_, _ = w.Write(buildLoadJSON())
 			}))
 

--- a/schema/generated/scalers-metadata-schema.json
+++ b/schema/generated/scalers-metadata-schema.json
@@ -847,6 +847,13 @@
                     "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "caseInsensitiveDemandsProcessing",
+                    "type": "string",
+                    "optional": true,
+                    "default": "false",
+                    "metadataVariableReadable": true
                 }
             ]
         },

--- a/schema/generated/scalers-metadata-schema.yaml
+++ b/schema/generated/scalers-metadata-schema.yaml
@@ -555,6 +555,11 @@ scalers:
           optional: true
           default: "false"
           metadataVariableReadable: true
+        - name: caseInsensitiveDemandsProcessing
+          type: string
+          optional: true
+          default: "false"
+          metadataVariableReadable: true
     - type: azure-queue
       parameters:
         - name: activationQueueLength


### PR DESCRIPTION
…ase insensitive

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
